### PR TITLE
added background workers for downloads

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,11 +6,15 @@ let expressSession = require("express-session");
 let logger = require("morgan");
 let stylus = require("stylus");
 let flash = require("connect-flash");
+const tmp = require("tmp");
 let models = require("./models");
 let passport = require("passport");
 let debug = require("debug")("aha-scoresheet:app");
 
 let coreRouter = require("./routes/core");
+
+// Clear temporary files on app process exit
+tmp.setGracefulCleanup();
 
 // Setup environmental variables
 require("dotenv").config();

--- a/package-lock.json
+++ b/package-lock.json
@@ -4968,6 +4968,14 @@
         "next-tick": "1"
       }
     },
+    "tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "requires": {
+        "rimraf": "^3.0.0"
+      }
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "sequelize-cli": "^6.2.0",
     "sequelize-pg-utilities": "^1.5.0",
     "stylus": "^0.54.8",
+    "tmp": "^0.2.1",
     "validator": "^13.1.1"
   },
   "devDependencies": {

--- a/views/index.pug
+++ b/views/index.pug
@@ -434,20 +434,46 @@ block content
     				scoresheetIds: [scoresheetId]
     			})
     		})
-    		.then(res => res.blob())
-    		.then(blobData => {
-    			download(blobData, `${scoresheetEntryNumber}.pdf`, 'application/pdf')
-          $(`#download-${scoresheetId}`).prop("disabled", false)
-          $(`#download-${scoresheetId}`).html('PDF')
+    		.then(res => res.json())
+    		.then(res => {
+          downloadHeartbeat(res.requestId, (blobData) => {
+            download(blobData, `${scoresheetEntryNumber}.pdf`, 'application/pdf')
+            $(`#download-${scoresheetId}`).prop("disabled", false)
+            $(`#download-${scoresheetId}`).html('PDF')
+          })
     		})
     	}
 
     	downloadAll = (scoresheetArray, flightId) => {
-        const requestId = Math.floor(10000000000*Math.random())
-        $(`#download-all-${flightId}`).prop("disabled", true)
-        $(`#download-all-${flightId}`).html(`<span class="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span><span id="${requestId}">0%</span> Downloaded`)
+        fetch('/scoresheet/pdf', {
+    			method: 'POST',
+    			headers: {
+    				'Content-Type': 'application/json'
+    			},
+    			body: JSON.stringify({
+    				scoresheetIds: scoresheetArray.map(scoresheet => scoresheet.id),
+    			})
+    		})
+    		.then(res => res.json())
+    		.then(res => {
+          $(`#download-all-${flightId}`).prop("disabled", true)
+          $(`#download-all-${flightId}`).html(`<span class="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span><span id="${res.requestId}">0%</span> Downloaded`)
 
-        const checkStatus = setInterval(() => {
+          downloadHeartbeat(res.requestId, (blobData) => {
+            if (scoresheetArray.length === 1) {
+              download(blobData, `${scoresheetArray[0].entry_number}.pdf`, 'application/pdf')
+            } else {
+              download(blobData, 'scoresheets.zip', 'application/zip')
+            }
+
+            $(`#download-all-${flightId}`).prop("disabled", false)
+            $(`#download-all-${flightId}`).html('Download All')
+          })
+    		})
+    	}
+
+      downloadHeartbeat = (requestId, completeCallback) => {
+        const downloadHeartbeatIntervalId = setInterval(() => {
           fetch('/scoresheet/downloadstatus', {
             method: 'POST',
             headers: {
@@ -457,33 +483,23 @@ block content
               requestId: requestId
             })
           })
-          .then(res => res.json())
-          .then(status => {
-            $(`#${requestId}`).text((100*(status.completed / status.total)).toFixed() + '%')
+          .then(res => {
+            if (res.status === 202) {
+              // Processing still in progress
+              res.json().then(status => {
+                $(`#${requestId}`).text((100*(status.completed / status.total)).toFixed() + '%')
+              })
+            } else if (res.status === 201) {
+              // Processing complete, recieving file
+              res.blob().then(blobData => {
+                clearInterval(downloadHeartbeatIntervalId)
+                completeCallback(blobData)
+              })
+            } else {
+              // Something went wrong
+              console.error('something went wrong', res.status)
+            }
           })
         }, 500)
-
-    		fetch('/scoresheet/pdf', {
-    			method: 'POST',
-    			headers: {
-    				'Content-Type': 'application/json'
-    			},
-    			body: JSON.stringify({
-    				scoresheetIds: scoresheetArray.map(scoresheet => scoresheet.id),
-            requestId: requestId
-    			})
-    		})
-    		.then(res => res.blob())
-    		.then(blobData => {
-    			if (scoresheetArray.length === 1) {
-    				download(blobData, `${scoresheetArray[0].entry_number}.pdf`, 'application/pdf')
-    			} else {
-    				download(blobData, 'scoresheets.zip', 'application/zip')
-    			}
-
-          clearInterval(checkStatus)
-          $(`#download-all-${flightId}`).prop("disabled", false)
-          $(`#download-all-${flightId}`).html('Download All')
-    		})
-    	}
+      }
     })


### PR DESCRIPTION
### Objective: 
- fixed #107 
- Eliminate open connections
- Prevent timeout issues for slow internet connections

### Changes
- Old pattern
  - Receive request to download pdf(s)
  - Await all promises from pdf generator service
  - Create empty archive
  - Pipe all pdfs into archive
  - Pipe archive to res
  - Status callback for progress only if client provided `requestId`
- New pattern
  - Receive request to download pdf(s)
  - Immediately return `requestId` to client
  - Background process creates pdfs and maps to temp file (as blob)
  - Client can check progress by using `requestId`
  - When complete, client is issued complete blob data during next heartbeat check
  - Cleanup occurs after data transmission is complete, or 1 minute after file is created