### PR TITLE
Master with logging

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -11,6 +11,12 @@
   "staging": {
     "use_env_variable": "DATABASE_URL",
     "dialect": "postgres",
+    "dialectOptions": {
+      "ssl": {
+        "require" : true,
+        "rejectUnauthorized": false
+      }
+    },
     "pool": {
       "max": 5,
       "min": 0,

--- a/controllers/ScoresheetController.js
+++ b/controllers/ScoresheetController.js
@@ -533,7 +533,7 @@ scoresheetController.generatePDF = function (req, res) {
                 "views/bjcp_modified.pug",
                 pdfGenInputData,
                 false,
-                500 * idx
+                1000 * idx
               )
               .then((scoresheetBlobData) => {
                 const fileName = `${pdfGenInputData[0].scoresheet.entry_number}.pdf`;
@@ -590,7 +590,7 @@ scoresheetController.generatePDF = function (req, res) {
                   images: static_image_paths,
                 },
                 false,
-                500 * idx
+                1000 * idx
               )
               .then((scoresheetBlobData) => {
                 const fileName = `${scoresheetData.scoresheet.entry_number}.pdf`;

--- a/public/javascripts/admin.js
+++ b/public/javascripts/admin.js
@@ -563,7 +563,7 @@ $(() => {
           console.error("something went wrong", res.status);
         }
       });
-    }, 500);
+    }, 1000);
   };
 
   getRawDataDump = () => {

--- a/services/pdf.service.js
+++ b/services/pdf.service.js
@@ -26,6 +26,8 @@ class PdfService {
   }
 
   async generateScoresheet(template, allData, preview) {
+    const timerMetric = Date.now();
+
     if (!this.initialized) {
       await this.browser;
     }
@@ -79,6 +81,12 @@ class PdfService {
           printBackground: true,
         });
         page.close();
+
+        console.log(
+          `PDF_SERVICE: Rendered ${allData.length} scoresheets for entry #${
+            allData[0].scoresheet.entry_number
+          } in ${Date.now() - timerMetric}ms`
+        );
         return pdfBuffer;
       }
     );

--- a/services/pdf.service.js
+++ b/services/pdf.service.js
@@ -94,11 +94,6 @@ class PdfService {
         });
         page.close();
 
-        console.log(
-          `PDF_SERVICE: Rendered ${allData.length} scoresheets for entry# ${
-            allData[0].scoresheet.entry_number
-          } in ${Date.now() - timerMetric}ms`
-        );
         return pdfBuffer;
       }
     );

--- a/services/pdf.service.js
+++ b/services/pdf.service.js
@@ -2,6 +2,8 @@ const puppeteer = require("puppeteer");
 const pug = require("pug");
 const fs = require("fs").promises;
 
+const MAX_SIMULTANEOUS_RENDERS = 10;
+
 class PdfService {
   constructor() {
     this.config = {
@@ -25,7 +27,10 @@ class PdfService {
     this.initialized = true;
   }
 
-  async generateScoresheet(template, allData, preview) {
+  async generateScoresheet(template, allData, preview, delay) {
+    if (delay) {
+      await new Promise((r) => setTimeout(r, delay));
+    }
     const timerMetric = Date.now();
 
     if (!this.initialized) {
@@ -73,6 +78,13 @@ class PdfService {
           return scoresheetHtml;
         }
 
+        let pages = await this.browser.pages();
+
+        while (pages.length == MAX_SIMULTANEOUS_RENDERS) {
+          pages = await this.browser.pages();
+          await new Promise((r) => setTimeout(r, 1000));
+        }
+
         const page = await this.browser.newPage();
         await page.setContent(scoresheetHtml);
         const pdfBuffer = await page.pdf({
@@ -83,7 +95,7 @@ class PdfService {
         page.close();
 
         console.log(
-          `PDF_SERVICE: Rendered ${allData.length} scoresheets for entry #${
+          `PDF_SERVICE: Rendered ${allData.length} scoresheets for entry# ${
             allData[0].scoresheet.entry_number
           } in ${Date.now() - timerMetric}ms`
         );

--- a/views/index.pug
+++ b/views/index.pug
@@ -500,6 +500,6 @@ block content
               console.error('something went wrong', res.status)
             }
           })
-        }, 500)
+        }, 1000)
       }
     })


### PR DESCRIPTION
* Added slight delay before sending scoresheets to pdf service
* Added hard cap for max simultaneous puppeteer renderers
* Fixed bug to prevent zip promise from resolving/compressing before blobs were piped into archive
* Increased heartbeat timeout from 500ms to 1000ms for download status request