### PR TITLE
Issues/74/add entry tab

### DIFF
--- a/controllers/ScoresheetController.js
+++ b/controllers/ScoresheetController.js
@@ -411,16 +411,7 @@ scoresheetController.generatePDF = function (req, res) {
               }, 60000);
             });
           });
-      } else if (
-        entryNumbers &&
-        Object.values(scoresheetObject).reduce(
-          (acc, scoresheet) =>
-            acc.includes(scoresheet.entry_number)
-              ? [...acc, scoresheet.entryNumbers]
-              : acc,
-          []
-        ).length === 1
-      ) {
+      } else if (entryNumbers && [...new Set(entryNumbers)].length === 1) {
         const pdfGenInputData = Object.values(scoresheetObject).map(
           (scoresheetData) => ({
             scoresheet: scoresheetData.scoresheet,

--- a/public/javascripts/admin.js
+++ b/public/javascripts/admin.js
@@ -29,6 +29,7 @@ const fetchAllData = () => {
         Scoresheets[scoresheet.id] = scoresheet;
       });
 
+      // Entries are scoresheets indexed against entry_number. Multiple scoresheets can have same entry number so we capture arrays here
       Entries = scoresheets.reduce((acc, scoresheet) => {
         acc[scoresheet.entry_number] = acc[scoresheet.entry_number] || {
           scoresheets: [],
@@ -39,6 +40,7 @@ const fetchAllData = () => {
           mini_boss_advanced: [],
         };
 
+        acc[scoresheet.entry_number].id = scoresheet.entry_number;
         acc[scoresheet.entry_number].entry_number = scoresheet.entry_number;
         acc[scoresheet.entry_number].scoresheets.push(scoresheet);
         acc[scoresheet.entry_number].category.push(
@@ -99,12 +101,12 @@ const updateAllTables = () => {
       $("#entries").find("table").DataTable().draw();
     });
 
-    $('[data-toggle="tooltip"]').tooltip();
-
     $("#flightModalUser").html("<option selected disabled>Select...</option>");
     Object.values(Users).forEach((user) => {
       $("#flightModalUser").append(new Option(user.email, user.id));
     });
+
+    $('[data-toggle="tooltip"]').tooltip();
   });
 };
 
@@ -193,14 +195,14 @@ const getDataValueByKey = (listItem, key) => {
   } else if (key === "date") {
     value = new Date(listItem[key]).toLocaleDateString();
   } else if (key === "numEntryScoresheets") {
-    const entryNumber = listItem.entry_number;
+    const entryNumber = listItem.id;
     value = Entries[entryNumber].scoresheets.length;
   } else if (key.split("_")[0] === "mismatched") {
-    const entryNumber = listItem.entry_number;
+    const entryNumber = listItem.id;
     const prop = key.split("_").slice(1).join("_");
 
     if (Entries[entryNumber][prop + "_contested"]) {
-      value = `<span class="material-icons" data-toggle="tooltip" data-placement="top" title="${Entries[
+      value = `<span class="material-icons" style="cursor:pointer;" data-toggle="tooltip" data-placement="top" title="${Entries[
         entryNumber
       ][prop]
         .map((val, idx) => {
@@ -247,6 +249,7 @@ const closeAllModals = () => {
 };
 
 $(() => {
+  $("#aboutContestedPopover").popover();
   updateAllTables();
 
   openFlightDataModal = (flightId) => {
@@ -323,7 +326,22 @@ $(() => {
   };
 
   openEntryDataModal = (entryNumber) => {
-    // TODO: Entry Modal!
+    const entry = Entries[entryNumber];
+    if (!entry) return;
+    closeAllModals();
+
+    // const flightScoresheetsHtml = Object.values(Scoresheets)
+    //   .filter((scoresheet) => scoresheet.flight_key === flightId)
+    //   .map((scoresheet) => generateScoresheetModalTableRow(scoresheet))
+    //   .join("");
+    $("#entryModalEntryNumber").val(entry.id);
+    $("#entryModalCategory").val(entry.scoresheets_first.category);
+    $("#entryModalSub").val(entry.scoresheets_first.sub);
+    $("#entryModalSubcat").val(entry.scoresheets_first.subcategory);
+
+    // $("#flightModalEntries").html(flightScoresheetsHtml);
+
+    $("#entryDataModal").modal("show");
   };
 
   updateUserData = () => {

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -63,4 +63,8 @@ body {
 .overflow-y-scroll {
   overflow-y: auto;
 }
+.modal-body {
+  max-height: 70vh;
+  overflow-y: auto;
+}
 /* NOTE! MAKE SURE TO EDIT IN .styl FILE AND NOT .css FILE! */

--- a/public/stylesheets/style.styl
+++ b/public/stylesheets/style.styl
@@ -83,4 +83,9 @@ body
   overflow-y: auto
 }
 
+.modal-body {
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
 /* NOTE! MAKE SURE TO EDIT IN .styl FILE AND NOT .css FILE! */

--- a/views/admin.pug
+++ b/views/admin.pug
@@ -73,9 +73,12 @@ block content
 
           #entries.tab-pane(role="tabpane2", aria-labelledby="entries-tab")
             .container-fluid
-              .form-check
-                  input.form-check-input(type="checkbox" id="filterByContested")
-                  label.form-check-label(for="filterByContested") Show Contested Only
+              .form-check.mb-2
+                .row
+                  .col-3
+                    input.form-check-input(type="checkbox" id="filterByContested")
+                    label.form-check-label(for="filterByContested") Show Nonuniform Only
+                    small.form-text.text-muted.link-style#aboutContestedPopover(data-toggle="popover" data-placement="bottom" title="About Nonuniform Entries" data-html="true" data-content="Nonuniform entries occur when two or more scoresheets with the same entry number have different values that judges should have agreed upon. <br><br>Tracked nonuniform values include: <ul><li>Category</li><li>Consensus Score</li><li>Place</li><li>MiniBOS Advance</li></ul>") What does this mean?
               table#entry_list_table.comp_entry_list.table.table-sm.table-striped.table-bordered.table-hover
                 thead.thead-dark
                   tr
@@ -95,7 +98,7 @@ block content
                 thead.thead-dark
                   tr
                     //- Table is generated dynamically by data-key in headers - to put more than one value in a cell, comma separate.
-                    th(scope="col", data-key="entry_number") Entry #
+                    th(scope="col", data-key="entry_number") Scoresheet #
                     th(scope="col", data-key="category,sub,subcategory") Category
                     th(scope="col", data-key="flight_key") Flight
                     th(scope="col", data-key="user_id") Judge
@@ -179,7 +182,7 @@ block content
                 th.text-center(scope="col") Place / Advance
                 th.text-center(scope="col") BOS
                 th.text-center(scope="col") PDF
-              tbody#flightModalEntries.overflow-y-scroll
+              tbody#flightModalEntries
         .modal-footer
           button.btn.btn-secondary(type="button", data-dismiss="modal") Cancel
           button.btn.btn-primary(type="button", onclick="updateFlightData()") Update Flight
@@ -294,7 +297,7 @@ block content
                 th(scope="col") Judging Date
                 th.text-center(scope="col") Judging Location
                 th.text-center(scope="col") # Entries
-              tbody#userModalFlights.overflow-y-scroll
+              tbody#userModalFlights
 
         .modal-footer
           button.btn.btn-secondary(type="button", data-dismiss="modal") Cancel
@@ -313,11 +316,11 @@ block content
           .form-group
             .row
               .col
-                #entryModalEntryContested
-                  h5.mb-1 #[span.material-icons warning] This entry is contested
-                  small.form-text.text-muted.link-style#aboutContestedPopover(data-toggle="popover" data-placement="bottom" title="About Contested Entries" data-html="true" data-content="Contested entries occur when two or more scoresheets with the same entry number have different common values. Common values include: <ul><li>Category</li><li>Consensus Score</li><li>Place</li><li>MiniBOS Advance</li></ul>") What does this mean?
+                #entryModalEntryContested(hidden)
+                  h5.mb-1.text-center.text-danger #[span.material-icons warning] This entry is not uniform
+                  small.text-center.form-text.text-muted.link-style#aboutContestedPopover(data-toggle="popover" data-placement="bottom" title="About Nonuniform Entries" data-html="true" data-content="Nonuniform entries occur when two or more scoresheets with the same entry number have different values that judges should have agreed upon. <br><br>Tracked nonuniform values include: <ul><li>Category</li><li>Consensus Score</li><li>Place</li><li>MiniBOS Advance</li></ul>") What does this mean?
               .col-auto.ml-auto
-                button.btn.btn-primary.ml-auto Download Entry Scoresheets
+                button.btn.btn-primary.ml-auto#downloadEntryScoresheetButton(onclick="downloadEntryScoresheet()") Download Entry Scoresheets
                 small.form-text.text-muted Combines all scoresheets for entry into one PDF
             hr
           .form-group
@@ -357,10 +360,10 @@ block content
                 th.text-center(scope="col") Place / Advance
                 th.text-center(scope="col") BOS
                 th.text-center(scope="col") PDF
-              tbody#flightModalEntries.overflow-y-scroll
+              tbody#entryModalScoresheets
         .modal-footer
           button.btn.btn-secondary(type="button", data-dismiss="modal") Cancel
-          button.btn.btn-primary(type="button", onclick="updateFlightData()") Update Entry
+          button.btn.btn-primary(type="button", onclick="updateEntryData()") Update Entry
 
   script(src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js")
   script(

--- a/views/admin.pug
+++ b/views/admin.pug
@@ -299,6 +299,68 @@ block content
         .modal-footer
           button.btn.btn-secondary(type="button", data-dismiss="modal") Cancel
           button.btn.btn-primary(type="button", onclick="updateUserData()") Update User Information
+  #entryDataModal.modal.fade(
+    tabindex="-1",
+    role="dialog",
+    aria-labelledby="entryDataModalLabel",
+    aria-hidden="true"
+  )
+    .modal-dialog.modal-lg
+      .modal-content
+        .modal-header 
+          h5 Entry Information
+        .modal-body
+          .form-group
+            .row
+              .col
+                #entryModalEntryContested
+                  h5.mb-1 #[span.material-icons warning] This entry is contested
+                  small.form-text.text-muted.link-style#aboutContestedPopover(data-toggle="popover" data-placement="bottom" title="About Contested Entries" data-html="true" data-content="Contested entries occur when two or more scoresheets with the same entry number have different common values. Common values include: <ul><li>Category</li><li>Consensus Score</li><li>Place</li><li>MiniBOS Advance</li></ul>") What does this mean?
+              .col-auto.ml-auto
+                button.btn.btn-primary.ml-auto Download Entry Scoresheets
+                small.form-text.text-muted Combines all scoresheets for entry into one PDF
+            hr
+          .form-group
+            .row
+              p.ml-3 Updating these parameters will change <strong>all scoresheets</strong> associated with this Entry Number.
+            .row
+              .col-4
+                label(for="entryModalEntryNumber") Entry Number
+                input#entryModalEntryNumber.form-control(
+                  type="text",
+                  placeholder="Entry or Judging Number"
+                )
+              .col-2
+                label(for="entryModalCategory") Category
+                select#entryModalCategory.form-control
+                  each category in [...Array(34).keys()]
+                    option #{category + 1}
+              .col-2
+                label(for="entryModalSub") Subcat
+                select#entryModalSub.form-control
+                  each sub in ['A', 'B', 'C', 'D', 'E', 'F']
+                    option #{sub}
+              .col-4
+                label(for="entryModalSubcat") Category Name
+                input#entryModalSubcat.form-control(
+                  type="text",
+                  placeholder="Full Category Name"
+                )
+          .table-responsive
+            table.table
+              thead
+                th.text-center(scope="col") Judge
+                th.text-center(scope="col") Flight
+                th.text-center(scope="col") Category
+                th.text-center(scope="col") Judge Score
+                th.text-center(scope="col") Consensus Score
+                th.text-center(scope="col") Place / Advance
+                th.text-center(scope="col") BOS
+                th.text-center(scope="col") PDF
+              tbody#flightModalEntries.overflow-y-scroll
+        .modal-footer
+          button.btn.btn-secondary(type="button", data-dismiss="modal") Cancel
+          button.btn.btn-primary(type="button", onclick="updateFlightData()") Update Entry
 
   script(src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js")
   script(

--- a/views/admin.pug
+++ b/views/admin.pug
@@ -10,7 +10,7 @@ block content
       .card-header
         ul#admin-list.nav.nav-tabs.card-header-tabs(role="tablist")
           li.nav-item
-            a.nav-link.px-2(
+            a.nav-link.px-2.active(
               data-toggle="tab",
               href="#system",
               role="tab",
@@ -18,7 +18,15 @@ block content
               aria-selected="true"
             ) System
           li.nav-item
-            a.nav-link.px-2.active(
+            a.nav-link.px-2(
+              data-toggle="tab",
+              href="#entries",
+              role="tab",
+              aria-controls="entries",
+              aria-selected="false"
+            ) Entries
+          li.nav-item
+            a.nav-link.px-2(
               data-toggle="tab",
               href="#scoresheets",
               role="tab",
@@ -43,7 +51,7 @@ block content
             ) Flights
       .card-body
         .tab-content
-          #system.tab-pane(role="tabpanel", aria-labelledby="system-tab")
+          #system.tab-pane.active(role="tabpanel", aria-labelledby="system-tab")
             .container-fluid
               .mt-5
                 label(for="download-all-entries-button") Download All Entries as Concatenated PDFs (Caution: May take a while!)
@@ -63,12 +71,27 @@ block content
                   onclick=`getRawDataDump()`
                 ) Download Raw Data
 
-          #scoresheets.tab-pane.active(
-            role="tabpane2",
-            aria-labelledby="scoresheets-tab"
-          )
+          #entries.tab-pane(role="tabpane2", aria-labelledby="entries-tab")
             .container-fluid
-              table.comp_entry_list.table.table-sm.table-striped.table-bordered.table-hover
+              .form-check
+                  input.form-check-input(type="checkbox" id="filterByContested")
+                  label.form-check-label(for="filterByContested") Show Contested Only
+              table#entry_list_table.comp_entry_list.table.table-sm.table-striped.table-bordered.table-hover
+                thead.thead-dark
+                  tr
+                    //- Table is generated dynamically by data-key in headers - to put more than one value in a cell, comma separate.
+                    //- Entries have the property '_first' to denote the first entry with that prop; if other sheets with the same entry number vary, the '_contested' prop is flagged as true
+                    th(scope="col", data-key="entry_number") Entry #
+                    th(scope="col", data-key="numEntryScoresheets") # Scoresheets
+                    th(scope="col", data-key="category_first, cat_name_first,mismatched_category") Category
+                    th(scope="col", data-key="consensus_score_first,mismatched_consensus_score") Consenseus
+                    th(scope="col", data-key="place_first,mismatched_place") Place
+                    th(scope="col", data-key="mini_boss_advanced_first,mismatched_mini_boss_advanced") Mini BOS
+                tbody
+              
+          #scoresheets.tab-pane(role="tabpane3", aria-labelledby="scoresheets-tab")
+            .container-fluid
+              table.comp_scoresheet_list.table.table-sm.table-striped.table-bordered.table-hover
                 thead.thead-dark
                   tr
                     //- Table is generated dynamically by data-key in headers - to put more than one value in a cell, comma separate.
@@ -76,11 +99,11 @@ block content
                     th(scope="col", data-key="category,sub,subcategory") Category
                     th(scope="col", data-key="flight_key") Flight
                     th(scope="col", data-key="user_id") Judge
-                    th(scope="col", data-key="consensus_score") Consenseus
+                    th(scope="col", data-key="judge_score") Judge Score
                     th(scope="col", data-key="place") Place
                     th(scope="col", data-key="mini_boss_advanced") Mini BOS
                 tbody
-          #judges.tab-pane(role="tabpane3", aria-labelledby="judges-tab")
+          #judges.tab-pane(role="tabpane4", aria-labelledby="judges-tab")
             .container-fluid
               table.comp_judges_list.table.table-sm.table-striped.table-bordered.table-hover
                 thead.thead-dark
@@ -92,7 +115,7 @@ block content
                     th(scope="col", data-key="numUserFlights") Judging Sessions
                     th(scope="col", data-key="numUserScoresheets") Entries Judged
                 tbody
-          #flights.tab-pane(role="tabpane4", aria-labelledby="flight-tab")
+          #flights.tab-pane(role="tabpane5", aria-labelledby="flight-tab")
             .container-fluid
               table.comp_flights_list.table.table-sm.table-striped.table-bordered.table-hover
                 thead.thead-dark

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -15,6 +15,7 @@ html
       rel="stylesheet",
       href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/10.6.1/css/bootstrap-slider.css"
     )
+    link(href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet")
     link(rel="stylesheet", href="/stylesheets/style.css")
 
     script(


### PR DESCRIPTION
* closed #74 
* Added entry tab that shows all scoresheets with same entry number
* Added modals to allow admins to quickly view / edit entry data (for all corresponding scoresheets)
* Added download button to concat download pdf by entry number (i.e. all scoresheets with that number in one file)
* Added "Nonuniform" warning markers to alert admins to entries that are potentially miscategorized or mismatched