### PR TITLE
Issues/135/remove duplicate db keys

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,10 @@ let passport = require("passport");
 let debug = require("debug")("aha-scoresheet:app");
 const db = require("./models/index");
 
+db.sequelize.sync().then(() => {
+  console.log("successfully updated models");
+});
+
 let coreRouter = require("./routes/core");
 
 // Clear temporary files on app process exit

--- a/app.js
+++ b/app.js
@@ -17,10 +17,6 @@ let passport = require("passport");
 let debug = require("debug")("aha-scoresheet:app");
 const db = require("./models/index");
 
-db.sequelize.sync().then(() => {
-  console.log("successfully updated models");
-});
-
 let coreRouter = require("./routes/core");
 
 // Clear temporary files on app process exit

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -70,35 +70,35 @@ userController.home = function (req, res) {
     return;
   }
 
-  const scoresheetPromise = Scoresheet.findAll({
-    where: {
-      user_id: req.user.id,
-    },
-  });
-
-  const flightPromise = Flight.findAll({
+  Flight.findAll({
     where: {
       created_by: req.user.id,
     },
-  });
+  })
+    .then((flights) => {
+      const plainFlights = flights.map((flight) => flight.get({ plain: true }));
 
-  Promise.all([scoresheetPromise, flightPromise])
-    .then(([scoresheets, flights]) => {
-      const flightObject = {};
+      const scoresheetPromises = plainFlights.map((flight) =>
+        Scoresheet.findAll({
+          where: {
+            flight_key: flight.id,
+          },
+        }).then((scoresheets) => {
+          return {
+            ...flight,
+            scoresheets: scoresheets.map((scoresheet) =>
+              scoresheet.get({ plain: true })
+            ),
+          };
+        })
+      );
 
-      flights.forEach((flight) => {
-        flightObject[flight.id] = {
-          ...flight.get({ plain: true }),
-          scoresheets: scoresheets
-            .filter((scoresheet) => scoresheet.flight_key === flight.id)
-            .map((scoresheet) => scoresheet.get({ plain: true })),
-        };
-      });
-
-      res.render("index", {
-        user: req.user,
-        title: appConstants.APP_NAME + " - Home",
-        flights: flightObject,
+      Promise.all(scoresheetPromises).then((flightObject) => {
+        res.render("index", {
+          user: req.user,
+          title: appConstants.APP_NAME + " - Home",
+          flights: flightObject,
+        });
       });
     })
     .catch((err) => {

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -72,7 +72,7 @@ userController.home = function (req, res) {
 
   Flight.findAll({
     where: {
-      created_by: req.user.id,
+      UserId: req.user.id,
     },
   })
     .then((flights) => {
@@ -81,7 +81,7 @@ userController.home = function (req, res) {
       const scoresheetPromises = plainFlights.map((flight) =>
         Scoresheet.findAll({
           where: {
-            flight_key: flight.id,
+            FlightId: flight.id,
           },
         }).then((scoresheets) => {
           return {

--- a/controllers/ScoresheetController.js
+++ b/controllers/ScoresheetController.js
@@ -26,7 +26,6 @@ function jsonErrorProcessor(err, res) {
     });
   } else {
     debug(err);
-    console.log(err);
     res.status(500).json(true);
   }
 }
@@ -111,11 +110,7 @@ scoresheetController.getScoresheetData = function (req, res) {
   }).then(async (scoresheetData) => {
     if (!scoresheetData) throw new Error("No scoresheet found!");
 
-    let user = scoresheetData.Flight.User;
-    delete user.password;
-    delete user.user_level;
-    delete user.created_at;
-    delete user.updated_at;
+    let user = scoresheetData.Flight.User.sanitize();
 
     let flight = scoresheetData.Flight.get({ plain: true });
     flight.flight_total = await Scoresheet.findAndCountAll({

--- a/migrations/20210201015101-remove-redundant-scoresheet-keys.js
+++ b/migrations/20210201015101-remove-redundant-scoresheet-keys.js
@@ -1,0 +1,95 @@
+"use strict";
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn("Scoresheets", "session_date");
+    await queryInterface.removeColumn("Scoresheets", "session_location");
+    await queryInterface.removeColumn("Scoresheets", "flight_total");
+    await queryInterface.removeColumn("Scoresheets", "scoresheet_submitted");
+    await queryInterface.removeColumn("Scoresheets", "judge_id");
+    await queryInterface.removeColumn("Scoresheets", "judge_name");
+    await queryInterface.removeColumn("Scoresheets", "judge_email");
+    await queryInterface.removeColumn("Scoresheets", "judge_bjcp_id");
+    await queryInterface.removeColumn("Scoresheets", "judge_bjcp_rank");
+    await queryInterface.removeColumn("Scoresheets", "judge_cicerone_rank");
+    await queryInterface.removeColumn(
+      "Scoresheets",
+      "judge_pro_brewer_brewery"
+    );
+    await queryInterface.removeColumn(
+      "Scoresheets",
+      "judge_industry_description"
+    );
+    await queryInterface.removeColumn("Scoresheets", "judge_judging_years");
+    await queryInterface.removeColumn("Scoresheets", "user_id");
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn("Scoresheets", "user_id", {
+      type: Sequelize.UUID,
+      references: {
+        model: "Users",
+        key: "id",
+      },
+      onUpdate: "CASCADE",
+      onDelete: "SET NULL",
+      allowNull: true,
+    });
+    await queryInterface.addColumn("Scoresheets", "session_date", {
+      type: Sequelize.DATE,
+      default: Sequelize.NOW,
+    });
+    await queryInterface.addColumn("Scoresheets", "session_location", {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+    await queryInterface.addColumn("Scoresheets", "flight_total", {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+    });
+    await queryInterface.addColumn("Scoresheets", "scoresheet_submitted", {
+      type: Sequelize.BOOLEAN,
+      default: false,
+    });
+    await queryInterface.addColumn("Scoresheets", "judge_id", {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+    await queryInterface.addColumn("Scoresheets", "judge_name", {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+    await queryInterface.addColumn("Scoresheets", "judge_email", {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+    await queryInterface.addColumn("Scoresheets", "judge_bjcp_id", {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+    await queryInterface.addColumn("Scoresheets", "judge_bjcp_rank", {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+    await queryInterface.addColumn("Scoresheets", "judge_cicerone_rank", {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+    await queryInterface.addColumn("Scoresheets", "judge_pro_brewer_brewery", {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+    await queryInterface.addColumn(
+      "Scoresheets",
+      "judge_industry_description",
+      {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      }
+    );
+    await queryInterface.addColumn("Scoresheets", "judge_judging_years", {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+  },
+};

--- a/migrations/20210201015101-remove-redundant-scoresheet-keys.js
+++ b/migrations/20210201015101-remove-redundant-scoresheet-keys.js
@@ -22,9 +22,13 @@ module.exports = {
     );
     await queryInterface.removeColumn("Scoresheets", "judge_judging_years");
     await queryInterface.removeColumn("Scoresheets", "user_id");
+    await queryInterface.renameColumn("Scoresheets", "flight_key", "FlightId");
+    await queryInterface.renameColumn("Flights", "created_by", "UserId");
   },
 
   down: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn("Scoresheets", "FlightId", "flight_key");
+    await queryInterface.renameColumn("Flights", "UserId", "created_by");
     await queryInterface.addColumn("Scoresheets", "user_id", {
       type: Sequelize.UUID,
       references: {

--- a/models/Flight.js
+++ b/models/Flight.js
@@ -1,4 +1,4 @@
-"use strict";
+// "use strict";
 
 module.exports = (sequelize, DataTypes) => {
   const Flight = sequelize.define(
@@ -14,7 +14,6 @@ module.exports = (sequelize, DataTypes) => {
       flight_id: DataTypes.STRING,
       location: DataTypes.STRING,
       date: DataTypes.STRING,
-      created_by: DataTypes.UUID,
       submitted: DataTypes.BOOLEAN,
     },
     {
@@ -26,8 +25,8 @@ module.exports = (sequelize, DataTypes) => {
   );
 
   Flight.associate = function (models) {
-    Flight.belongsTo(models.User, { foreignKey: "id", as: "userId" });
-    Flight.hasMany(models.Scoresheet, { foreignKey: "id" });
+    Flight.belongsTo(models.User);
+    Flight.hasMany(models.Scoresheet);
   };
 
   return Flight;

--- a/models/Flight.js
+++ b/models/Flight.js
@@ -26,7 +26,8 @@ module.exports = (sequelize, DataTypes) => {
   );
 
   Flight.associate = function (models) {
-    Flight.hasMany(models.Scoresheet, { as: "scoresheets", foreignKey: "id" });
+    Flight.belongsTo(models.User, { foreignKey: "id", as: "userId" });
+    Flight.hasMany(models.Scoresheet, { foreignKey: "id" });
   };
 
   return Flight;

--- a/models/Scoresheet.js
+++ b/models/Scoresheet.js
@@ -33,13 +33,6 @@ module.exports = (sequelize, DataTypes) => {
           msg: "Improperly formatter ID provided.",
         },
       },
-      session_date: {
-        type: DataTypes.DATE,
-        default: DataTypes.NOW,
-      },
-      session_location: {
-        type: DataTypes.STRING,
-      },
       category: {
         type: DataTypes.STRING,
       },
@@ -58,9 +51,6 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.STRING,
       },
       flight_position: {
-        type: DataTypes.NUMBER,
-      },
-      flight_total: {
         type: DataTypes.NUMBER,
       },
       mini_boss_advanced: {
@@ -288,32 +278,6 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.NUMBER,
         default: 0,
       },
-      scoresheet_submitted: {
-        type: DataTypes.BOOLEAN,
-        default: false,
-      },
-      user_id: {
-        type: DataTypes.UUID,
-        allowNull: true,
-      },
-      judge_id: {
-        type: DataTypes.STRING,
-        allowNull: true,
-      },
-      judge_name: {
-        type: DataTypes.STRING,
-        allowNull: true,
-      },
-      judge_email: {
-        type: DataTypes.STRING,
-        allowNull: true,
-      },
-      judge_bjcp_id: DataTypes.STRING,
-      judge_bjcp_rank: DataTypes.STRING,
-      judge_cicerone_rank: DataTypes.STRING,
-      judge_pro_brewer_brewery: DataTypes.STRING,
-      judge_industry_description: DataTypes.STRING,
-      judge_judging_years: DataTypes.STRING,
       flight_key: {
         type: DataTypes.UUID,
         allowNull: true,
@@ -327,7 +291,6 @@ module.exports = (sequelize, DataTypes) => {
 
   Scoresheet.associate = function (models) {
     // associations can be defined here
-    Scoresheet.belongsTo(models.User, { foreignKey: "id", as: "userID" });
     Scoresheet.belongsTo(models.Flight, { foreignKey: "id", as: "flightID" });
   };
 

--- a/models/Scoresheet.js
+++ b/models/Scoresheet.js
@@ -1,23 +1,4 @@
-"use strict";
-
-/**
- * stringEmpty will trim and test if the string is not empty
- * @param s
- * @param msg
- * @returns {boolean}
- */
-function stringEmpty(s, msg) {
-  // Make sure this is even a value
-  if (!s) return false;
-  // Make sure there is no white space
-  s = s.trim();
-  // Make sure it's not empty
-  if (s === "") {
-    throw new Error(msg);
-  }
-  // It's a good value
-  return true;
-}
+// "use strict";
 
 module.exports = (sequelize, DataTypes) => {
   const Scoresheet = sequelize.define(
@@ -278,10 +259,6 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.NUMBER,
         default: 0,
       },
-      flight_key: {
-        type: DataTypes.UUID,
-        allowNull: true,
-      },
     },
     {
       createdAt: "created_at",
@@ -291,7 +268,7 @@ module.exports = (sequelize, DataTypes) => {
 
   Scoresheet.associate = function (models) {
     // associations can be defined here
-    Scoresheet.belongsTo(models.Flight, { foreignKey: "id", as: "flightID" });
+    Scoresheet.belongsTo(models.Flight);
   };
 
   return Scoresheet;

--- a/models/User.js
+++ b/models/User.js
@@ -87,9 +87,9 @@ module.exports = (sequelize, DataTypes) => {
 
   User.associate = function (models) {
     // associations can be defined here
-    User.hasMany(models.Scoresheet, {
-      as: "scoresheets",
-      foreignKey: "user_id",
+    User.hasMany(models.Flight, {
+      as: "flights",
+      foreignKey: "created_by",
     });
   };
 

--- a/models/User.js
+++ b/models/User.js
@@ -85,6 +85,19 @@ module.exports = (sequelize, DataTypes) => {
     return bcrypt.hash(password, bcrypt.genSaltSync(10), null);
   };
 
+  User.prototype.sanitize = function () {
+    const user = { ...this.get({ plain: true }) };
+    delete user.password;
+    delete user.user_level;
+    delete user.created_at;
+    delete user.updated_at;
+    delete user.verification_id;
+    delete user.password_reset_id;
+    delete user.allow_automated_email;
+    delete user.email_verified;
+    return user;
+  };
+
   User.associate = function (models) {
     // associations can be defined here
     User.hasMany(models.Flight);

--- a/models/User.js
+++ b/models/User.js
@@ -1,4 +1,4 @@
-"use strict";
+// "use strict";
 
 var bcrypt = require("bcryptjs");
 
@@ -87,10 +87,7 @@ module.exports = (sequelize, DataTypes) => {
 
   User.associate = function (models) {
     // associations can be defined here
-    User.hasMany(models.Flight, {
-      as: "flights",
-      foreignKey: "created_by",
-    });
+    User.hasMany(models.Flight);
   };
 
   return User;

--- a/views/admin.pug
+++ b/views/admin.pug
@@ -51,13 +51,15 @@ block content
             ) Flights
       .card-body
         .tab-content
-          #system.tab-pane.active(role="tabpanel", aria-labelledby="system-tab")
+          #system.tab-pane.active(
+            role="tabpanel",
+            aria-labelledby="system-tab"
+          )
             .container-fluid
               .mt-5
                 label(for="download-all-entries-button") Download All Entries as Concatenated PDFs (Caution: May take a while!)
                 br
-                button.btn.btn-primary(
-                  id="download-all-entries-button",
+                button#download-all-entries-button.btn.btn-primary(
                   type="button",
                   onclick=`downloadAllEntries()`
                 ) Download All Scoresheets
@@ -65,8 +67,7 @@ block content
               .mt-5
                 label(for="download-all-raw-data-button") Download All Scoresheet Data as CSV
                 br
-                button.btn.btn-primary(
-                  id="download-all-raw-data-button",
+                button#download-all-raw-data-button.btn.btn-primary(
                   type="button",
                   onclick=`getRawDataDump()`
                 ) Download Raw Data
@@ -76,9 +77,15 @@ block content
               .form-check.mb-2
                 .row
                   .col-3
-                    input.form-check-input(type="checkbox" id="filterByContested")
+                    input#filterByContested.form-check-input(type="checkbox")
                     label.form-check-label(for="filterByContested") Show Nonuniform Only
-                    small.form-text.text-muted.link-style#aboutContestedPopover(data-toggle="popover" data-placement="bottom" title="About Nonuniform Entries" data-html="true" data-content="Nonuniform entries occur when two or more scoresheets with the same entry number have different values that judges should have agreed upon. <br><br>Tracked nonuniform values include: <ul><li>Category</li><li>Consensus Score</li><li>Place</li><li>MiniBOS Advance</li></ul>") What does this mean?
+                    small#aboutContestedPopover.form-text.text-muted.link-style(
+                      data-toggle="popover",
+                      data-placement="bottom",
+                      title="About Nonuniform Entries",
+                      data-html="true",
+                      data-content="Nonuniform entries occur when two or more scoresheets with the same entry number have different values that judges should have agreed upon. <br><br>Tracked nonuniform values include: <ul><li>Category</li><li>Consensus Score</li><li>Place</li><li>MiniBOS Advance</li></ul>"
+                    ) What does this mean?
               table#entry_list_table.comp_entry_list.table.table-sm.table-striped.table-bordered.table-hover
                 thead.thead-dark
                   tr
@@ -86,13 +93,25 @@ block content
                     //- Entries have the property '_first' to denote the first entry with that prop; if other sheets with the same entry number vary, the '_contested' prop is flagged as true
                     th(scope="col", data-key="entry_number") Entry #
                     th(scope="col", data-key="numEntryScoresheets") # Scoresheets
-                    th(scope="col", data-key="category_first, cat_name_first,mismatched_category") Category
-                    th(scope="col", data-key="consensus_score_first,mismatched_consensus_score") Consenseus
+                    th(
+                      scope="col",
+                      data-key="category_first, cat_name_first,mismatched_category"
+                    ) Category
+                    th(
+                      scope="col",
+                      data-key="consensus_score_first,mismatched_consensus_score"
+                    ) Consenseus
                     th(scope="col", data-key="place_first,mismatched_place") Place
-                    th(scope="col", data-key="mini_boss_advanced_first,mismatched_mini_boss_advanced") Mini BOS
+                    th(
+                      scope="col",
+                      data-key="mini_boss_advanced_first,mismatched_mini_boss_advanced"
+                    ) Mini BOS
                 tbody
-              
-          #scoresheets.tab-pane(role="tabpane3", aria-labelledby="scoresheets-tab")
+
+          #scoresheets.tab-pane(
+            role="tabpane3",
+            aria-labelledby="scoresheets-tab"
+          )
             .container-fluid
               table.comp_scoresheet_list.table.table-sm.table-striped.table-bordered.table-hover
                 thead.thead-dark
@@ -100,9 +119,9 @@ block content
                     //- Table is generated dynamically by data-key in headers - to put more than one value in a cell, comma separate.
                     th(scope="col", data-key="entry_number") Scoresheet #
                     th(scope="col", data-key="category,sub,subcategory") Category
-                    th(scope="col", data-key="flight_key") Flight
-                    th(scope="col", data-key="user_id") Judge
-                    th(scope="col", data-key="judge_score") Judge Score
+                    th(scope="col", data-key="FlightId") Flight
+                    th(scope="col", data-key="UserId") Judge
+                    th(scope="col", data-key="judge_total") Judge Score
                     th(scope="col", data-key="place") Place
                     th(scope="col", data-key="mini_boss_advanced") Mini BOS
                 tbody
@@ -125,7 +144,7 @@ block content
                   tr
                     //- Table is generated dynamically by data-key in headers - to put more than one value in a cell, comma separate.
                     th(scope="col", data-key="flight_id") FlightID
-                    th(scope="col", data-key="created_by") Judge
+                    th(scope="col", data-key="UserId") Judge
                     th(scope="col", data-key="date") Date
                     th(scope="col", data-key="location") Location
                     th(scope="col", data-key="numFlightEntries") Entries
@@ -318,9 +337,17 @@ block content
               .col
                 #entryModalEntryContested(hidden)
                   h5.mb-1.text-center.text-danger #[span.material-icons warning] This entry is not uniform
-                  small.text-center.form-text.text-muted.link-style#aboutContestedPopover(data-toggle="popover" data-placement="bottom" title="About Nonuniform Entries" data-html="true" data-content="Nonuniform entries occur when two or more scoresheets with the same entry number have different values that judges should have agreed upon. <br><br>Tracked nonuniform values include: <ul><li>Category</li><li>Consensus Score</li><li>Place</li><li>MiniBOS Advance</li></ul>") What does this mean?
+                  small#aboutContestedPopover.text-center.form-text.text-muted.link-style(
+                    data-toggle="popover",
+                    data-placement="bottom",
+                    title="About Nonuniform Entries",
+                    data-html="true",
+                    data-content="Nonuniform entries occur when two or more scoresheets with the same entry number have different values that judges should have agreed upon. <br><br>Tracked nonuniform values include: <ul><li>Category</li><li>Consensus Score</li><li>Place</li><li>MiniBOS Advance</li></ul>"
+                  ) What does this mean?
               .col-auto.ml-auto
-                button.btn.btn-primary.ml-auto#downloadEntryScoresheetButton(onclick="downloadEntryScoresheet()") Download Entry Scoresheets
+                button#downloadEntryScoresheetButton.btn.btn-primary.ml-auto(
+                  onclick="downloadEntryScoresheet()"
+                ) Download Entry Scoresheets
                 small.form-text.text-muted Combines all scoresheets for entry into one PDF
             hr
           .form-group

--- a/views/bjcp_modified.pug
+++ b/views/bjcp_modified.pug
@@ -95,7 +95,7 @@ body
           span Date
           span.user_input_truncated.display_iblock.lheight_normal.text_center(
             style="width:150px;"
-          ) #{new Date(scoresheet.session_date).toLocaleDateString()}
+          ) #{new Date(flight.date).toLocaleDateString()}
       .row.clearfix
         .entry_information.text_normal.float_left
           .row

--- a/views/bjcp_modified.pug
+++ b/views/bjcp_modified.pug
@@ -144,7 +144,7 @@ body
             .col.col_40
               span.border_solid_1.display_iblock.height_20p.text_center.text_resize_marker(
                 style="width: 35px;line-height: 20px;font-stretch: var(--fontStretch);font-size: var(--fontSize);"
-              ) #{scoresheet.flight_total}
+              ) #{flight.flight_total}
         .border_solid_1.float_left.text_size_50.mleft_15
           .border_bot_solid_1(style="height: 18px")
             span.display_iblock.text_center.float_left(style="width: 46px;")

--- a/views/scoresheet.pug
+++ b/views/scoresheet.pug
@@ -2,14 +2,7 @@ extends layout
 
 block content
   form#newScoresheet(role="form", action="/scoresheet/update", method="post")
-    input#author(type="text", name="author", value=user._id, hidden)
-    input#id(type="text", name="id", hidden, value=fingerprint)
-    input#scoresheet_submitted(
-      type="text",
-      value="0",
-      name="scoresheet_submitted",
-      hidden
-    )
+    input#id(type="text", name="id", hidden, value=scoresheetId)
     input#FlightId(type="text", name="FlightId", hidden, value=flightId)
     .container
       .card
@@ -34,9 +27,7 @@ block content
                     p.small.mb-0.text-center MiniBOS
                   .card-body.text-dark.px-0.py-1.text-center
                     .btn-group-toggle(data-toggle="buttons")
-                      label.btn.btn-outline-success.btn-sm(
-                        class=Boolean(scoresheet ? scoresheet.mini_boss_advanced : false) ? 'active' : ''
-                      ) Advance
+                      label#mini_boss_advanced_label.btn.btn-outline-success.btn-sm Advance
                         input#mini_boss_advanced(
                           type="checkbox",
                           autocomplete="off",
@@ -136,43 +127,26 @@ block content
                   .form-group.col-sm-2.col-form-label Judge
                     label(for="judge_name")
                   .form-group.col-sm-4
-                    input#judge_name.form-control(
-                      type="text",
-                      value=user.firstname + ' ' + user.lastname,
-                      disabled
-                    )
+                    input#judge_name.form-control(type="text", disabled)
                   .form-group.col-sm-1.col-form-label BJCP ID
                     label(for="bjcp_id")
                   .form-group.col-sm-2
-                    input#bjcp_id.form-control(
-                      type="text",
-                      value=user.bjcp_id,
-                      readonly
-                    )
+                    input#bjcp_id.form-control(type="text", readonly)
                   .form-group.col-sm-1.col-form-label Rank
                     label(for="bjcp_rank")
                   .form-group.col-sm-2
-                    input#bjcp_rank.form-control(
-                      type="text",
-                      value=user.bjcp_rank,
-                      readonly
-                    )
+                    input#bjcp_rank.form-control(type="text", readonly)
                 .form-row.py-1
                   .form-group.col-sm-2.col-form-label Session Date
-                    label(for="session_date")
+                    label(for="date")
                   .form-group.col-sm-4
-                    input#session_date.form-control(
-                      type="date",
-                      name="session_date",
-                      value=sess_date
-                    )
+                    input#date.form-control(type="date", name="date", disabled)
                   .form-group.col-sm-2.col-form-label Session Location
-                    label(for="session_location")
+                    label(for="location")
                   .form-group.col-sm-4
-                    input#session_location.form-control(
+                    input#location.form-control(
                       type="text",
-                      name="session_location",
-                      value=session_location,
+                      name="location",
                       disabled
                     )
 
@@ -196,8 +170,7 @@ block content
                     input#flight_position.form-control(
                       type="number",
                       name="flight_position",
-                      min="0",
-                      value=flight_position
+                      min="0"
                     )
                   .form-group.col-sm-1.col-form-label.text-center
                     label(for="flight_total") of
@@ -205,8 +178,7 @@ block content
                     input#flight_total.form-control(
                       type="number",
                       name="flight_total",
-                      min="0",
-                      value=flight_total
+                      disabled
                     )
               .form-group
                 .form-row.py-1

--- a/views/scoresheet.pug
+++ b/views/scoresheet.pug
@@ -10,7 +10,7 @@ block content
       name="scoresheet_submitted",
       hidden
     )
-    input#flight_key(type="text", name="flight_key", hidden, value=flightId)
+    input#FlightId(type="text", name="FlightId", hidden, value=flightId)
     .container
       .card
         .card-header


### PR DESCRIPTION
Ok boiz, buckle up - this one's a doozy
* Fixes 135 (for real this time)
* Fixes #64 
* Fixes #85
* Fixes #92 

Changes:
* Refactored Sequelize models to use associations properly
* Added migration to remove redundant keys and implement Sequelize association keys
  * From `Scoresheet`: All user info (including UserId), all flight info. Changed `flight_key` to `FlightID`, `flight_total` removed (dynamically calculated from Flight)
  * From `Flight`: Changed `created_by` to `UserId`
* Refactored a TON of things to use `UserId` in Flight instead of scoresheet to avoid having a duplicate UserId

Tests:
* Migrations and new schema tested with sqlite3 and Postgres locally